### PR TITLE
Display signup messages

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -21,6 +21,7 @@ html
                 = link_to("Log out",
                           destroy_user_session_path(:store_unique_id => nil),
                           :method => :delete)
+                = link_to("Manage your profile", edit_user_registration_path)
             - else
               li.nav id="right"
                 = link_to("Sign up", new_user_path)
@@ -36,7 +37,7 @@ html
               li.nav = link_to "View Cart", cart_path(@store)
       
     - flash.each do |name, msg|
-      = content_tag :div, msg, :id => "flash_#{name}"
+      = content_tag :div, msg.html_safe, :id => "flash_#{name}"
 
     div class="navbar navbar-fixed-bottom"
       div class="navbar-inner"

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -34,7 +34,7 @@ en:
       send_paranoid_instructions: 'If your e-mail exists on our database, you will receive an email with instructions about how to confirm your account in a few minutes.'
       confirmed: 'Your account was successfully confirmed. You are now signed in.'
     registrations:
-      signed_up: 'Welcome! You have signed up successfully.'
+      signed_up: 'Welcome! You have signed up successfully. <a href="/users/edit">Change your account</a>'
       signed_up_but_unconfirmed: 'A message with a confirmation link has been sent to your email address. Please open the link to activate your account.'
       signed_up_but_inactive: 'You have signed up successfully. However, we could not sign you in because your account is not yet activated.'
       signed_up_but_locked: 'You have signed up successfully. However, we could not sign you in because your account is locked.'

--- a/spec/requests/user_requests_spec.rb
+++ b/spec/requests/user_requests_spec.rb
@@ -44,11 +44,7 @@ describe User, :user_request => :user do
   end
 
   context "after signing up" do
-    let(:user) { User.new(name: Faker::Name.first_name,
-                          email: Faker::Internet.email,
-                          username: Faker::Name.first_name,
-                          password: Faker::Lorem.words(1).first
-                          )}
+    let(:user) { Fabricate.build(:user) }
     it "user sees a confirmation flash message with a link to change their account" do
       visit new_user_path
       complete_user_form(user)

--- a/spec/requests/user_requests_spec.rb
+++ b/spec/requests/user_requests_spec.rb
@@ -44,6 +44,18 @@ describe User, :user_request => :user do
   end
 
   context "after signing up" do
+    let(:user) { User.new(name: Faker::Name.first_name,
+                          email: Faker::Internet.email,
+                          username: Faker::Name.first_name,
+                          password: Faker::Lorem.words(1).first
+                          )}
+    it "user sees a confirmation flash message with a link to change their account" do
+      visit new_user_path
+      complete_user_form(user)
+      click_button "Sign up"
+      page.should have_content("Change your account")
+    end
+
     it "user receives confirmation email" do
       expect { create_user(user) }.to change(ActionMailer::Base.deliveries,:size).by(1)
     end


### PR DESCRIPTION
When signing up for the first time, a user will receive the flash message "Welcome! You have signed up successfully." with a 'change your account' link to the devise/registration#edit page. Additionally submitting a test in the user spec to check for this on account sign up and tweaked the application layout to include a direct link to the devise/registration#edit page. Tested at 100% coverage and clean cane and reek. 

Amended to include fabricator to build a test user in my spec tests.  Hopefully this pulls everything through cleanly.
